### PR TITLE
Context: Expose instruction count

### DIFF
--- a/core/engine/src/context/mod.rs
+++ b/core/engine/src/context/mod.rs
@@ -527,6 +527,13 @@ impl Context {
         Ok(self.enter_realm(old_realm))
     }
 
+    /// Get the remaining instruction count
+    #[cfg(feature = "fuzz")]
+    #[inline]
+    pub const fn instructions_remaining(&self) -> usize {
+        self.instructions_remaining
+    }
+    
     /// Get the [`RootShape`].
     #[inline]
     #[must_use]


### PR DESCRIPTION
Exposes the instruction counter and fix a bug allowing unreachable behaviour.

* If the "fuzz" feature is enabled the `instructions_remaining` counter is a public property.
* The `NoInstructionsRemaining` error can now be converted into a javascript error, preventing boa from panicking if the error is thrown async 
