### PR TITLE
fix(engine): conversion from undefined to JSON

### DIFF
--- a/core/engine/src/value/conversions/serde_json.rs
+++ b/core/engine/src/value/conversions/serde_json.rs
@@ -115,7 +115,9 @@ impl JsValue {
     pub fn to_json(&self, context: &mut Context) -> JsResult<Value> {
         match self {
             Self::Null => Ok(Value::Null),
-            Self::Undefined => todo!("undefined to JSON"),
+            Self::Undefined => Err(JsNativeError::typ()
+                .with_message("cannot convert undefined to JSON")
+                .into()),
             &Self::Boolean(b) => Ok(b.into()),
             Self::String(string) => Ok(string.to_std_string_escaped().into()),
             &Self::Rational(rat) => Ok(rat.into()),


### PR DESCRIPTION
**Context**
[Related task](https://app.asana.com/0/1205770721173531/1206712599227131/f)

Currently converting undefined to JSON panics, which causes jstz kernel to hang. We should throw a JS error Instead of panicking.  
** Test ** 

To locally test, check out my branch locally, replace the following under the [patch.crates-io] with your local path in `Cargo.toml`
```
boa_ast = { git = "https://github.com/trilitech/boa.git", branch = "sam.finch@/context/expose-instruction-count" }
boa_engine = { git = "https://github.com/trilitech/boa.git", branch = "sam.finch@/context/expose-instruction-count" }
boa_gc = { git = "https://github.com/trilitech/boa.git", branch = "sam.finch@/context/expose-instruction-count" }
boa_interner = { git = "https://github.com/trilitech/boa.git", branch = "sam.finch@/context/expose-instruction-count" }
boa_macros = { git = "https://github.com/trilitech/boa.git", branch = "sam.finch@/context/expose-instruction-count" }
boa_parser = { git = "https://github.com/trilitech/boa.git", branch = "sam.finch@/context/expose-instruction-count" }
boa_profiler = { git = "https://github.com/trilitech/boa.git", branch = "sam.finch@/context/expose-instruction-count" }
``` 

Tested that kernel doesn't hang in case undefined is passed to Kv.set
Repl: 
Before:
<img width="559" alt="Screenshot 2024-03-06 at 19 58 06" src="https://github.com/trilitech/boa/assets/128799322/b23456d3-90e3-4eba-b800-7650b3e99934">
After:
<img width="535" alt="Screenshot 2024-03-06 at 19 51 59" src="https://github.com/trilitech/boa/assets/128799322/225751e0-e3e4-41c4-a23e-5ee2f034760b">


